### PR TITLE
Add fix for blender 4.1

### DIFF
--- a/nns_model.py
+++ b/nns_model.py
@@ -811,7 +811,9 @@ class NitroModel():
     def process_mesh(self, node, obj):
         primitives = []
 
-        obj.data.calc_normals_split()
+        # fix copied from fast64 repo, in blender version 4.1 func was removed, in 4.1+ normals are always calculated
+        if bpy.app.version < (4, 1, 0):
+            obj.data.calc_normals_split()
 
         for polygon in obj.data.polygons:
             if len(polygon.loop_indices) > 4:


### PR DESCRIPTION
Only run obj.data.calc_normals_split() on versions post-4.1.0. This fix was literally copy pasted 1-1 from fast64 which suffered from the same API change. 