### PR TITLE
Update vertex coloring to be compatible with newer versions

### DIFF
--- a/nns_model.py
+++ b/nns_model.py
@@ -294,8 +294,12 @@ class NitroModelMtxPrim():
             primitive.sort_key = 0
             primitive.quad_size += int((prim.vertex_count - 2) / 2)
 
-        if len(obj.data.vertex_colors) > 0 and "vc" in material.type:
-            self.parent_polygon.use_clr = True
+        if bpy.app.version >= (3, 2, 0):
+            if obj.data.color_attributes.active:
+                self.parent_polygon.use_clr = True
+        else:
+            if len(obj.data.vertex_colors) > 0 and "vc" in material.type:
+                self.parent_polygon.use_clr = True
 
         if material.image_idx != -1 and "tx" in material.type \
                 and material.tex_gen_mode != "nrm" \

--- a/primitive.py
+++ b/primitive.py
@@ -387,8 +387,12 @@ class Primitive():
 
         use_colors = False
 
-        if len(obj.data.vertex_colors) > 0:
-            use_colors = True
+        if bpy.app.version >= (3, 2, 0):
+            if obj.data.color_attributes.active:
+                use_colors = True
+        else:
+            if len(obj.data.vertex_colors) > 0:
+                use_colors = True
 
         for idx in polygon.loop_indices:
             # Get vertex and convert it to VecFx32.
@@ -407,9 +411,16 @@ class Primitive():
 
             # Color
             if use_colors:
+                color = (0, 0, 0)
+
                 # Use special function to get color because the vertex colors
                 # may not align with the vertex loops.
-                color = get_color_from_obj(obj, idx)
+
+                if bpy.app.version >= (3, 2, 0):
+                    color = get_color_from_obj(obj, vertex_index)
+                else:
+                    color = get_color_from_obj(obj, idx)
+
                 r = int(round(color[0] * 31))
                 g = int(round(color[1] * 31))
                 b = int(round(color[2] * 31))

--- a/util.py
+++ b/util.py
@@ -8,10 +8,17 @@ def get_color_from_obj(obj, idx):
     to be aligned with the vertex loops. Possibly this happens when you import a
     wrong model.
     """
-    if len(obj.data.vertex_colors[0].data) <= idx:
-        return (0, 0, 0)
+
+    if bpy.app.version >= (3, 2, 0):
+        if (len(obj.data.color_attributes.active_color.data) <= idx):
+            return(0, 0, 0)
+        else:
+            return(obj.data.color_attributes.active_color.data[idx].color)
     else:
-        return obj.data.vertex_colors[0].data[idx].color
+        if len(obj.data.vertex_colors[0].data) <= idx:
+            return(0, 0, 0)
+        else:
+            return(obj.data.vertex_colors[0].data[idx].color)
 
 
 def is_pos_s(vecfx32):


### PR DESCRIPTION
This is built to be backwards compatible with Blender versions below 3.2.0, in which the change from vertex colors to color attributes was made. This was tested with both versions 3.0.1 and 5.1.2.

As a side note, models loaded from a previous version of Blender into a newer one seem to have issues even with this fix in place. Previously, the vertex colors would not get exported at all, however if loading a <3.2.0 blend file in a later version and exporting that, it will now simply result in incorrect vertex color placement.